### PR TITLE
Fix prompt path resolution for UNC execution

### DIFF
--- a/researcher.py
+++ b/researcher.py
@@ -3,12 +3,15 @@ from agno.models.openai import OpenAIChat
 from agno.tools.tavily import TavilyTools
 from agno.playground import Playground, serve_playground_app
 import yaml
+from pathlib import Path
 
 from dotenv import load_dotenv
 load_dotenv()
 
 
-prompt = yaml.safe_load(open("prompts/researcher.yaml"))
+ROOT = Path(__file__).resolve().parent
+PROMPT_PATH = ROOT / "prompts" / "researcher.yaml"
+prompt = yaml.safe_load(PROMPT_PATH.open())
 researcher = Agent(
     model=OpenAIChat(id="gpt-4.1-mini"),
     name="Researcher",


### PR DESCRIPTION
## Summary
- ensure `prompts/researcher.yaml` is loaded relative to the script location

## Testing
- `python researcher.py` *(fails: ModuleNotFoundError: No module named 'agno')*

------
https://chatgpt.com/codex/tasks/task_e_6854495c014c8323ad938cf214e6d14f